### PR TITLE
Redesign UI with Playful Cube type-color system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules/
 # Turbo
 .turbo
 .log
+
+# Superpowers brainstorming companion
+.superpowers/

--- a/apps/client/src/lib/components/AlgorithmView.svelte
+++ b/apps/client/src/lib/components/AlgorithmView.svelte
@@ -18,23 +18,23 @@
 
 <div
 	class={[
-		'flex flex-col justify-center rounded-md border border-base-300',
-		{ 'mb-2 border-2': isMain }
+		'flex flex-col gap-1 rounded-field border px-3 py-2 text-center',
+		isMain ? 'border-(--type-accent)/35 bg-base-200/60' : 'border-base-300 bg-base-200/30'
 	]}
 >
 	<span
 		class={[
-			'flex items-center justify-center gap-1 p-1 text-center',
-			isMain ? 'text-2xl font-bold' : 'text-xl'
+			'flex flex-wrap items-center justify-center gap-x-1.5 gap-y-0.5 font-mono tracking-wide',
+			isMain ? 'text-xl font-bold sm:text-2xl' : 'text-base sm:text-lg'
 		]}
 	>
 		{algorithm.rotations}
 		<AlgorithmVerifier algorithm={algorithm.rotations} {setup} onlyError={slim} {viewType} />
 	</span>
 	{#if showMnemonic}
-		<span class="text-center text-lg text-base-content/80">{algorithm.mnemonics}</span>
+		<span class="text-sm text-base-content/75 italic">{algorithm.mnemonics}</span>
 	{/if}
 	{#if showDescription}
-		<span class="text-center text-base text-base-content/60">{algorithm.description}</span>
+		<span class="text-xs text-base-content/55">{algorithm.description}</span>
 	{/if}
 </div>

--- a/apps/client/src/lib/components/AlgorithmsList.svelte
+++ b/apps/client/src/lib/components/AlgorithmsList.svelte
@@ -22,14 +22,16 @@
 	const hasMore = $derived(otherAlgorithms.length > limitedOtherAlgorithms.length);
 </script>
 
-<div class={[className, 'flex flex-col gap-1']}>
+<div class={[className, 'flex flex-col gap-2']}>
 	<AlgorithmView {setup} algorithm={mainAlgorithm} {slim} {viewType} isMain />
 	{#each limitedOtherAlgorithms as algorithm (algorithm.id)}
 		<AlgorithmView {setup} {algorithm} {slim} {viewType} />
 	{/each}
 	{#if hasMore}
-		<span class="badge self-center badge-outline">
-			+{otherAlgorithms.length - limitedOtherAlgorithms.length}
+		<span
+			class="self-center rounded-full border border-base-300 px-2.5 py-0.5 text-xs font-semibold text-base-content/60"
+		>
+			+{otherAlgorithms.length - limitedOtherAlgorithms.length} more
 		</span>
 	{/if}
 </div>

--- a/apps/client/src/lib/components/Breadcrumbs.svelte
+++ b/apps/client/src/lib/components/Breadcrumbs.svelte
@@ -11,13 +11,17 @@
 	const active = $derived(breadcrumbs.at(-1));
 </script>
 
-<div class="breadcrumbs text-sm">
+<div class="breadcrumbs px-2 text-sm">
 	<ul>
 		{#each links as link (link.href)}
-			<li><a href={link.href}>{link.name}</a></li>
+			<li>
+				<a href={link.href} class="text-base-content/55 transition-colors hover:text-base-content">
+					{link.name}
+				</a>
+			</li>
 		{/each}
 		{#if active}
-			<li>{active.name}</li>
+			<li class="font-semibold">{active.name}</li>
 		{/if}
 	</ul>
 </div>

--- a/apps/client/src/lib/components/CaseView.svelte
+++ b/apps/client/src/lib/components/CaseView.svelte
@@ -11,36 +11,41 @@
 	let { case: c, slim }: Props = $props();
 </script>
 
-<div id={c.id} class="@container card w-full bg-base-200 p-2">
-	<div
-		class="card-body grid grid-cols-[8rem_1fr] grid-rows-[auto_1fr_auto] items-center justify-center gap-2 p-2 @lg:grid-cols-[15rem_1fr]"
-	>
-		<div class="col-start-1 row-span-2 row-start-1">
+<article
+	id={c.id}
+	data-type={c.viewType}
+	class="@container relative w-full overflow-hidden rounded-box border border-base-300 bg-(--type-tint) shadow-sm transition-shadow group-hover:shadow-lg"
+>
+	<span class="absolute inset-y-0 left-0 w-1.5 bg-(--type-accent)"></span>
+	<div class="flex items-center gap-4 p-4 pl-5 @lg:gap-6 @lg:p-6 @lg:pl-7">
+		<div class="size-28 shrink-0 @lg:size-40">
 			<CubeView algorithm={c.setup} type={c.viewType} />
 		</div>
-		<div
-			class="col-span-2 col-start-1 row-start-3 flex flex-col items-center rounded-md border-2 border-base-300 p-2"
-		>
-			<div>Setup</div>
-			<div class="divider my-1"></div>
-			<span class="text-center">{c.setup}</span>
+		<div class="flex min-w-0 flex-1 flex-col gap-3">
+			<div class="flex flex-wrap items-center gap-2">
+				<h2 class="text-2xl font-extrabold tracking-tight">{c.name}</h2>
+				{#if slim}
+					<span
+						class="rounded-full bg-(--type-pill) px-2.5 py-0.5 text-xs font-bold text-(--type-pill-content)"
+					>
+						{c.subset.name}
+					</span>
+				{:else}
+					<a
+						href={`/${c.subset.setId}/${c.subset.id}#${c.id}`}
+						class="rounded-full bg-(--type-pill) px-2.5 py-0.5 text-xs font-bold text-(--type-pill-content) transition-opacity hover:opacity-80"
+					>
+						{c.subset.name}
+					</a>
+				{/if}
+			</div>
+
+			<AlgorithmsList viewType={c.viewType} setup={c.setup} algorithms={c.algorithms} {slim} />
+
+			<p class="flex flex-wrap items-baseline gap-x-2 text-xs text-base-content/55">
+				<span class="font-bold tracking-wide text-base-content/45 uppercase">Setup</span>
+				<span class="font-mono">{c.setup}</span>
+			</p>
 		</div>
-		<div class="flex items-center justify-center gap-1">
-			<span class="text-2xl font-bold">{c.name}</span>
-			{#if slim}
-				<span class="badge">{c.subset.name}</span>
-			{:else}
-				<a href={`/${c.subset.setId}/${c.subset.id}#${c.id}`}>
-					<span class="badge">{c.subset.name}</span>
-				</a>
-			{/if}
-		</div>
-		<AlgorithmsList
-			class="self-start"
-			viewType={c.viewType}
-			setup={c.setup}
-			algorithms={c.algorithms}
-			{slim}
-		/>
 	</div>
-</div>
+</article>

--- a/apps/client/src/lib/components/CasesList.svelte
+++ b/apps/client/src/lib/components/CasesList.svelte
@@ -10,13 +10,21 @@
 	let { cases, slim }: Props = $props();
 </script>
 
-<div class="flex flex-col items-center gap-4">
+<div class="flex flex-col gap-4">
 	{#each cases as c (c.id)}
-		<a class="w-full" href={`/${c.subset.setId}/${c.subset.id}/${c.id}`}>
+		<a
+			href={`/${c.subset.setId}/${c.subset.id}/${c.id}`}
+			data-type={c.viewType}
+			class="group block w-full rounded-box transition-transform duration-150 hover:-translate-y-0.5 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--type-accent)"
+		>
 			<CaseView case={c} {slim} />
 		</a>
 	{/each}
 	{#if cases.length === 0}
-		<div class="text-2xl uppercase">No cases</div>
+		<div
+			class="rounded-box border border-dashed border-base-300 p-10 text-center text-base-content/50"
+		>
+			No cases found.
+		</div>
 	{/if}
 </div>

--- a/apps/client/src/lib/components/Preview.svelte
+++ b/apps/client/src/lib/components/Preview.svelte
@@ -27,7 +27,7 @@
 	{href}
 	data-type={all ? 'all' : viewType}
 	class={[
-		'relative block w-36 overflow-hidden rounded-box border bg-base-100 transition-all duration-150',
+		'relative flex w-36 flex-col items-center gap-2 overflow-hidden rounded-box border bg-base-100 p-4 transition-all duration-150',
 		'hover:-translate-y-0.5 hover:shadow-md',
 		isActive
 			? 'border-(--type-accent) shadow-[0_0_0_1px_var(--type-accent)]'
@@ -36,13 +36,13 @@
 >
 	<span class={['absolute inset-x-0 top-0 h-1', all ? 'cube-gradient' : 'bg-(--type-accent)']}
 	></span>
-	<div class="flex flex-col items-center gap-2 p-4 pt-5">
-		<h2 class="text-center font-bold tracking-tight">{name}</h2>
-		<div class="size-20">
-			<CubeView algorithm={previewAlgorithm} type={viewType} />
-		</div>
-		<span class="rounded-full bg-base-200 px-2.5 py-0.5 text-xs font-semibold text-base-content/70">
-			{size}
-		</span>
+	<div class="size-20">
+		<CubeView algorithm={previewAlgorithm} type={viewType} />
 	</div>
+	<h2 class="text-center font-bold tracking-tight">{name}</h2>
+	<span
+		class="mt-auto rounded-full bg-base-200 px-2.5 py-0.5 text-xs font-semibold text-base-content/70"
+	>
+		{size}
+	</span>
 </a>

--- a/apps/client/src/lib/components/Preview.svelte
+++ b/apps/client/src/lib/components/Preview.svelte
@@ -9,19 +9,40 @@
 		previewAlgorithm: string;
 		viewType: ViewType;
 		isActive?: boolean;
+		all?: boolean;
 	}
 
-	let { name, size, href, previewAlgorithm, viewType, isActive = false }: Props = $props();
+	let {
+		name,
+		size,
+		href,
+		previewAlgorithm,
+		viewType,
+		isActive = false,
+		all = false
+	}: Props = $props();
 </script>
 
-<a {href} class={['rounded-box', { 'ring-2 ring-cube-green': isActive }]}>
-	<div class="card bg-base-200">
-		<div class="card-body items-center gap-2 p-4">
-			<h2 class="card-title text-center">{name}</h2>
-			<div class="size-20">
-				<CubeView algorithm={previewAlgorithm} type={viewType} />
-			</div>
-			<span class="badge badge-neutral">{size}</span>
+<a
+	{href}
+	data-type={all ? 'all' : viewType}
+	class={[
+		'relative block w-36 overflow-hidden rounded-box border bg-base-100 transition-all duration-150',
+		'hover:-translate-y-0.5 hover:shadow-md',
+		isActive
+			? 'border-(--type-accent) shadow-[0_0_0_1px_var(--type-accent)]'
+			: 'border-base-300 shadow-sm'
+	]}
+>
+	<span class={['absolute inset-x-0 top-0 h-1', all ? 'cube-gradient' : 'bg-(--type-accent)']}
+	></span>
+	<div class="flex flex-col items-center gap-2 p-4 pt-5">
+		<h2 class="text-center font-bold tracking-tight">{name}</h2>
+		<div class="size-20">
+			<CubeView algorithm={previewAlgorithm} type={viewType} />
 		</div>
+		<span class="rounded-full bg-base-200 px-2.5 py-0.5 text-xs font-semibold text-base-content/70">
+			{size}
+		</span>
 	</div>
 </a>

--- a/apps/client/src/lib/components/PreviewList.svelte
+++ b/apps/client/src/lib/components/PreviewList.svelte
@@ -10,7 +10,7 @@
 	let { items }: Props = $props();
 </script>
 
-<div class="flex flex-wrap gap-1">
+<div class="flex flex-wrap gap-3">
 	{#each items as item (item.href)}
 		<Preview {...item} isActive={item.href === page.url.pathname} />
 	{/each}

--- a/apps/client/src/lib/data/types.ts
+++ b/apps/client/src/lib/data/types.ts
@@ -63,6 +63,8 @@ export interface PreviewItem {
 	previewAlgorithm: string;
 	size: number;
 	viewType: ViewType;
+	/** True for the home "All" chip, which spans every type and uses the neutral cube-gradient accent. */
+	all?: boolean;
 }
 
 export interface Breadcrumb {

--- a/apps/client/src/lib/layout/AppSidebar.svelte
+++ b/apps/client/src/lib/layout/AppSidebar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { GalleryVerticalEnd, Search } from '@lucide/svelte';
+	import { Box, Search } from '@lucide/svelte';
 	import { page } from '$app/state';
 	import type { SidebarSet } from '$lib/data/types';
 
@@ -28,19 +28,21 @@
 	});
 
 	const isActive = (href: string) => page.url.pathname === href;
+
+	const activeBar = 'shadow-[inset_3px_0_0_0_var(--type-accent)]';
 </script>
 
-<aside class="flex min-h-full w-72 flex-col gap-2 bg-base-200 p-4">
-	<a href="/" class="flex items-center gap-2 px-2 py-1">
+<aside class="flex min-h-full w-72 flex-col gap-3 border-r border-base-300 bg-base-100 p-4">
+	<a href="/" class="flex items-center gap-2.5 px-2 py-1">
 		<span
-			class="flex size-8 items-center justify-center rounded-lg bg-primary text-primary-content"
+			class="cube-gradient flex size-8 items-center justify-center rounded-lg text-white shadow-sm"
 		>
-			<GalleryVerticalEnd class="size-4" />
+			<Box class="size-4" />
 		</span>
-		<span class="font-semibold">Algorithms</span>
+		<span class="text-base font-bold tracking-tight">Algorithms</span>
 	</a>
 
-	<label class="input input-sm w-full">
+	<label class="input input-sm w-full rounded-field">
 		<Search class="size-4 opacity-50" />
 		<input
 			type="search"
@@ -50,16 +52,28 @@
 		/>
 	</label>
 
-	<ul class="menu w-full grow flex-nowrap overflow-y-auto">
+	<ul class="menu w-full grow flex-nowrap gap-0.5 overflow-y-auto px-0">
 		{#each filtered as set (set.id)}
-			<li>
-				<a href={`/${set.id}`} class="font-semibold">{set.name}</a>
-				<ul>
+			<li data-type={set.viewType}>
+				<a
+					href={`/${set.id}`}
+					class={[
+						'gap-2.5 font-semibold transition-colors',
+						isActive(`/${set.id}`) && `bg-(--type-soft) ${activeBar}`
+					]}
+				>
+					<span class="size-2.5 rounded-[3px] bg-(--type-accent)"></span>
+					{set.name}
+				</a>
+				<ul class="border-base-300">
 					{#each set.subsets as subset (subset.id)}
 						<li>
 							<a
 								href={`/${set.id}/${subset.id}`}
-								class:menu-active={isActive(`/${set.id}/${subset.id}`)}
+								class={[
+									'transition-colors',
+									isActive(`/${set.id}/${subset.id}`) && `bg-(--type-soft) font-medium ${activeBar}`
+								]}
 							>
 								{subset.name}
 							</a>
@@ -68,7 +82,11 @@
 									<li>
 										<a
 											href={`/${set.id}/${subset.id}/${c.id}`}
-											class:menu-active={isActive(`/${set.id}/${subset.id}/${c.id}`)}
+											class={[
+												'transition-colors',
+												isActive(`/${set.id}/${subset.id}/${c.id}`) &&
+													`bg-(--type-soft) font-medium ${activeBar}`
+											]}
 										>
 											{c.name}
 										</a>

--- a/apps/client/src/routes/+layout.svelte
+++ b/apps/client/src/routes/+layout.svelte
@@ -19,8 +19,8 @@
 
 <div class="drawer lg:drawer-open">
 	<input id="app-drawer" type="checkbox" class="drawer-toggle" />
-	<div class="drawer-content flex min-h-screen flex-col">
-		<header class="navbar border-b border-base-300 bg-base-100">
+	<div class="drawer-content flex min-h-screen flex-col bg-base-200">
+		<header class="navbar sticky top-0 z-20 border-b border-base-300 bg-base-100/85 backdrop-blur">
 			<label for="app-drawer" class="btn btn-square btn-ghost lg:hidden" aria-label="Open sidebar">
 				<Menu class="size-5" />
 			</label>
@@ -29,11 +29,13 @@
 			</div>
 			<ThemeToggle />
 		</header>
-		<main class="flex-1 p-4">
-			{@render children()}
+		<main class="flex-1 p-4 sm:p-6">
+			<div class="mx-auto w-full max-w-5xl">
+				{@render children()}
+			</div>
 		</main>
 	</div>
-	<div class="drawer-side z-10">
+	<div class="drawer-side z-30">
 		<label for="app-drawer" class="drawer-overlay" aria-label="Close sidebar"></label>
 		<AppSidebar sidebar={data.sidebar} />
 	</div>

--- a/apps/client/src/routes/+page.ts
+++ b/apps/client/src/routes/+page.ts
@@ -8,7 +8,14 @@ export const load: PageLoad = () => {
 	const allCases = getAllCases();
 
 	const items: PreviewItem[] = [
-		{ href: '/', name: 'All', previewAlgorithm: '', size: allCases.length, viewType: 'PLL' },
+		{
+			href: '/',
+			name: 'All',
+			previewAlgorithm: '',
+			size: allCases.length,
+			viewType: 'PLL',
+			all: true
+		},
 		...sets.map((set) => ({
 			href: `/${set.id}`,
 			name: set.name,

--- a/apps/client/src/routes/layout.css
+++ b/apps/client/src/routes/layout.css
@@ -1,9 +1,80 @@
 @import 'tailwindcss';
+@plugin 'daisyui';
 
-@plugin 'daisyui' {
-	themes:
-		dark --default,
-		light;
+/* ===== Custom daisyUI themes — "Playful Cube" tuned surfaces ===== */
+/* base-100 is the clean, raised surface (cards/sidebar/navbar);            */
+/* base-200 is the page behind them; base-300 is borders/dividers.         */
+
+@plugin 'daisyui/theme' {
+	name: 'dark';
+	default: true;
+	prefersdark: true;
+	color-scheme: dark;
+
+	--color-base-100: #20202e;
+	--color-base-200: #15151f;
+	--color-base-300: #2f2f42;
+	--color-base-content: #f2f3f8;
+	--color-primary: #ff7a33;
+	--color-primary-content: #1a0a00;
+	--color-secondary: #a78bfa;
+	--color-secondary-content: #1a0033;
+	--color-accent: #1cb35a;
+	--color-accent-content: #04140d;
+	--color-neutral: #2a2a3c;
+	--color-neutral-content: #d6d7e3;
+	--color-info: #5b8bff;
+	--color-info-content: #03102e;
+	--color-success: #34d07a;
+	--color-success-content: #04140d;
+	--color-warning: #ffce3a;
+	--color-warning-content: #1a1400;
+	--color-error: #f0556a;
+	--color-error-content: #2a0007;
+
+	--radius-selector: 0.5rem;
+	--radius-field: 0.5rem;
+	--radius-box: 1rem;
+	--size-selector: 0.25rem;
+	--size-field: 0.25rem;
+	--border: 1px;
+	--depth: 1;
+	--noise: 0;
+}
+
+@plugin 'daisyui/theme' {
+	name: 'light';
+	color-scheme: light;
+
+	--color-base-100: #ffffff;
+	--color-base-200: #f2f4f7;
+	--color-base-300: #e3e7ee;
+	--color-base-content: #1b2230;
+	--color-primary: #ff5900;
+	--color-primary-content: #ffffff;
+	--color-secondary: #7c3aed;
+	--color-secondary-content: #ffffff;
+	--color-accent: #16a34a;
+	--color-accent-content: #ffffff;
+	--color-neutral: #1b2230;
+	--color-neutral-content: #f2f4f7;
+	--color-info: #2f6dff;
+	--color-info-content: #ffffff;
+	--color-success: #16a34a;
+	--color-success-content: #ffffff;
+	--color-warning: #e0a200;
+	--color-warning-content: #1a1400;
+	--color-error: #dc2626;
+	--color-error-content: #ffffff;
+
+	--radius-selector: 0.5rem;
+	--radius-field: 0.5rem;
+	--radius-box: 1rem;
+	--size-selector: 0.25rem;
+	--size-field: 0.25rem;
+	--border: 1px;
+	--depth: 1;
+	--noise: 0;
 }
 
 @theme {
@@ -18,4 +89,70 @@
 	--grid-template-columns-cube-flat: 0 repeat(3, 5fr) 0;
 	--grid-template-rows-cube: 1fr repeat(3, 5fr) 1fr;
 	--grid-template-rows-cube-flat: 0 repeat(3, 5fr) 0;
+}
+
+/* ===== Type accent system =====
+ * Color-code by algorithm type. A `data-type` attribute on a container sets
+ * `--type-accent` (+ content/tint/soft), which descendant utilities consume
+ * via `bg-(--type-accent)`, `border-(--type-accent)`, `text-(--type-accent)`,
+ * `ring-(--type-accent)`, `bg-(--type-tint)`, etc.
+ * Accents are contrast-tuned cousins of the real cube colors so text/borders
+ * stay legible on both themes; the cube stickers keep their true colors. */
+
+:root {
+	--color-type-f2l: #16a34a;
+	--color-type-oll: #e0a200;
+	--color-type-pll: #2f6dff;
+}
+
+[data-theme='dark'] {
+	--color-type-f2l: #1cb35a;
+	--color-type-oll: #ffce3a;
+	--color-type-pll: #5b8bff;
+}
+
+/* `--type-accent` drives bars/dots/rings/tints (no text on them, so it can be
+ * bright). `--type-pill` is a separate, AA-safe solid background for the small
+ * bold type pills, which DO carry text. */
+
+[data-type='F2L'] {
+	--type-accent: var(--color-type-f2l);
+	--type-accent-content: #ffffff;
+	--type-tint: color-mix(in srgb, var(--color-type-f2l) 7%, var(--color-base-100));
+	--type-soft: color-mix(in srgb, var(--color-type-f2l) 16%, transparent);
+	--type-pill: #15803d;
+	--type-pill-content: #ffffff;
+}
+
+[data-type='OLL'] {
+	--type-accent: var(--color-type-oll);
+	--type-accent-content: #1a1400;
+	--type-tint: color-mix(in srgb, var(--color-type-oll) 7%, var(--color-base-100));
+	--type-soft: color-mix(in srgb, var(--color-type-oll) 16%, transparent);
+	--type-pill: #e0a200;
+	--type-pill-content: #1a1400;
+}
+
+[data-type='PLL'] {
+	--type-accent: var(--color-type-pll);
+	--type-accent-content: #ffffff;
+	--type-tint: color-mix(in srgb, var(--color-type-pll) 7%, var(--color-base-100));
+	--type-soft: color-mix(in srgb, var(--color-type-pll) 16%, transparent);
+	--type-pill: #2563eb;
+	--type-pill-content: #ffffff;
+}
+
+[data-type='all'] {
+	--type-accent: #8b8ba0;
+	--type-accent-content: #ffffff;
+	--type-tint: var(--color-base-100);
+	--type-soft: color-mix(in srgb, var(--color-base-content) 8%, transparent);
+	--type-pill: #5b5b6e;
+	--type-pill-content: #ffffff;
+	--type-gradient: linear-gradient(135deg, #009b48, #ffd500 52%, #ff5900);
+}
+
+/* Shared cube-gradient (logo mark, the "All" chip edge) */
+.cube-gradient {
+	background-image: linear-gradient(135deg, #009b48, #ffd500 52%, #ff5900);
 }

--- a/docs/superpowers/specs/2026-06-04-ui-cleanup-playful-cube-design.md
+++ b/docs/superpowers/specs/2026-06-04-ui-cleanup-playful-cube-design.md
@@ -1,0 +1,115 @@
+# UI Cleanup — "Playful Cube" Design
+
+**Date:** 2026-06-04
+**Status:** Approved (visual direction signed off via brainstorming companion)
+**Scope:** Visual refresh of the SvelteKit client (`apps/client`). Surfaces only — no new features, no data-model changes, no changes to the cube-rendering internals or the cube engine.
+
+## Goal
+
+Make the Rubik's-cube algorithm trainer look prettier and more cohesive. The current UI is functional but flat and monotone: nearly everything is the same `bg-base-200` card on a slightly darker background, with heavy nested borders, weak hierarchy, and no depth, hover states, or color identity.
+
+The approved direction is **"Playful Cube"**: lean into the toy. A type-based color system, the cube as the hero of each card, clearer typography hierarchy, real elevation, and subtle motion — kept tasteful/refined, not loud.
+
+## Decisions (locked during brainstorming)
+
+1. **Both themes.** Keep the existing light + dark toggle; apply the new look to both. Dark stays the default.
+2. **Color-code by algorithm type.** Each `viewType` gets a signature color used consistently across the sidebar, the type chips, and the case cards:
+   - **F2L → green**, **OLL → gold**, **PLL → blue**, **"All" (home only) → cube gradient**.
+   - The actual cube *stickers* keep their true cube colors. The *UI chrome* uses contrast-tuned cousins of those colors so text/borders stay legible on both white and dark backgrounds.
+3. **Refined, not loud.** Energy comes from the accent bars, colored pills, the gradient logo mark, and a subtle hover lift — not from gradient titles or strong tints. (User approved this balance.)
+4. **Surfaces only.** Restyle the sidebar, top bar, chips, case cards, algorithm blocks, breadcrumbs, and theme toggle across every page. Leave `lib/components/cube/*` (the 2D cube grid) and the `packages/cube` engine untouched.
+
+The approved mockups live at `.superpowers/brainstorm/<session>/content/playful-refined.html` (git-ignored).
+
+## Visual language / tokens
+
+All new tokens live in `apps/client/src/routes/layout.css`. The existing cube-color tokens and grid templates there stay as-is (the cube components depend on them).
+
+### Type accent colors
+
+Defined as theme-scoped CSS custom properties. Starting values from the approved mockup — **each must be re-verified for WCAG AA against the surface it sits on during implementation** (gold and blue are the risky ones):
+
+| Type | Light accent | Dark accent | Pill text |
+| --- | --- | --- | --- |
+| F2L (green) | `#16a34a` | `#1cb35a` | white (darken to `#15803d` if white-on-green fails AA) |
+| OLL (gold) | `#e0a200` | `#ffce3a` | near-black `#1a1400` |
+| PLL (blue) | `#2f6dff` | `#5b8bff` | white |
+| All (home) | cube gradient `linear-gradient(90deg,#009b48,#ffd500,#ff5900)` | same | n/a |
+
+Implementation pattern — a `data-type` attribute drives a local CSS variable so we avoid a per-color class explosion and keep components DRY:
+
+```css
+/* in layout.css, theme-scoped for the contrast-tuned values */
+@theme {
+  --color-type-f2l: #16a34a;
+  --color-type-oll: #e0a200;
+  --color-type-pll: #2f6dff;
+}
+[data-theme='dark'] {
+  --color-type-f2l: #1cb35a;
+  --color-type-oll: #ffce3a;
+  --color-type-pll: #5b8bff;
+}
+/* map a type onto a single local accent var consumed by components */
+[data-type='F2L'] { --type-accent: var(--color-type-f2l); --type-accent-content: #fff; }
+[data-type='OLL'] { --type-accent: var(--color-type-oll); --type-accent-content: #1a1400; }
+[data-type='PLL'] { --type-accent: var(--color-type-pll); --type-accent-content: #fff; }
+```
+
+> Note: name the variable `--type-accent` (NOT `--accent`) to avoid colliding with daisyUI's own semantic tokens. Components set `data-type={viewType}` on their root and consume `var(--type-accent)` (e.g. `bg-(--type-accent)`, `border-(--type-accent)`, or small scoped CSS). The home **"All"** chip uses the gradient via a dedicated class, not `--type-accent`.
+
+### Surfaces, elevation, radius
+
+Tune the daisyUI `light` and `dark` themes (via daisyUI 5 theme config — **use the `daisyui` skill for the exact `@plugin "daisyui/theme"` syntax**) toward the mockup's calmer, slightly indigo-tinted palette. Target values (verify in the live preview; daisyUI uses `base-200/300` internally for inputs/hover, so check those components after):
+
+- **Elevation rule:** page background = `bg-base-200`; raised surfaces (cards, sidebar, navbar) = `bg-base-100` + `border-base-300` + a soft shadow. Choose values so **base-100 reads as lighter/raised above base-200 in both themes**.
+  - Light: `base-100 #ffffff`, `base-200 #f2f4f7`, `base-300 #e3e7ee`, `base-content #1b2230`.
+  - Dark: `base-100 #20202e`, `base-200 #15151f`, `base-300 #2e2e42`, `base-content #f2f3f8`.
+- **Radius:** bump daisyUI `--radius-box` / `--radius-field` toward the friendlier `~14–16px` / `~9px` used in the mockup.
+- **Type tint:** case cards get a faint wash of their type color via `color-mix(in srgb, var(--type-accent) 6%, var(--color-base-100))`.
+- **Motion:** interactive cards (chips, case cards) get `transition` + a small hover lift (`translateY(-2px)` + slightly stronger shadow). Subtle only.
+
+### Typography hierarchy (per card)
+
+Cube (hero) · **bold case name** · colored **type pill** · main **algorithm** in a monospace chip with the ✓ verifier dot inline · optional muted-italic **mnemonic** · quiet **"Setup · … / +N algs"** footer. This replaces the current stack of equally-weighted bordered boxes.
+
+## Per-component changes
+
+Files under `apps/client/src/`. Each keeps its current props/behavior unless noted.
+
+| File | Change |
+| --- | --- |
+| `routes/layout.css` | Add type-accent tokens + `[data-type=…]` rules; customize daisyUI light/dark base surfaces + radius (via daisyui skill). Keep existing cube tokens/grids. |
+| `routes/+layout.svelte` | Page bg `bg-base-200`; navbar/header on `bg-base-100` with `border-base-300`; comfortable `main` padding; optional content max-width on very wide screens. Drawer/mobile behavior unchanged. |
+| `lib/layout/AppSidebar.svelte` | Gradient cube **logo mark**; refined search input; set headers get a **type-colored dot** (`data-type={set.viewType}`); active subset/case gets a **type-colored left bar + tint** (replacing the default `menu-active`); hover states. `SidebarSet` already carries `viewType`. |
+| `lib/components/Preview.svelte` | Chip: **type-colored top edge**, active → **ring in `--type-accent`** (replace the hardcoded `ring-cube-green`), count badge, hover lift. Render gradient/neutral when the new `all` flag is set. |
+| `lib/components/PreviewList.svelte` | Spacing/wrap polish only. |
+| `lib/data/types.ts` | Add `all?: boolean` to `PreviewItem` (explicit "all-types" marker for the neutral gradient chip). |
+| `routes/+page.ts` | Set `all: true` on the root **"All"** item only. (Stops the gradient chip from inheriting the misleading hardcoded `viewType: 'PLL'`.) |
+| `lib/components/CaseView.svelte` | Rebuild the card: root `data-type={c.viewType}`; **left accent bar** + faint **type tint**; cube as hero (CubeView untouched, just its rounded container/size); header = bold name + **type pill**; **demote Setup** from the big bordered box to a quiet footer line; drop heavy nested borders. Preserve `id={c.id}` (deep-link anchor) and the `slim` vs full behavior. |
+| `lib/components/CasesList.svelte` | Hover affordance on the link wrapper; spacing; restyle the empty "No cases" state. Keep `<a>`-wraps-`<CaseView slim>`. |
+| `lib/components/AlgorithmsList.svelte` | Emphasize the main algorithm, lighten the others; restyle the "+N" pill. Keep the limit logic. |
+| `lib/components/AlgorithmView.svelte` | Algorithm in a **monospace chip** (subtle border, rounded) with the verifier inline; main larger; mnemonic muted-italic; description smaller/muted. Reduce the `border-2`. |
+| `lib/components/AlgorithmVerifier.svelte` | Keep correct/incorrect semantics + accessible titles; align colors with `success`/`error` tokens. Minor. |
+| `lib/components/Breadcrumbs.svelte` | Refine type/separators/hover. Minor. |
+| `lib/components/ThemeToggle.svelte` | Keep logic; restyle the button to match. Minor. |
+
+## Constraints
+
+- **No nested `<a>`.** Slim case cards are wrapped in an `<a>` by `CasesList`; keep their internals anchor-free (subset shows as a span, not a link, when `slim`). The full (detail) card is not wrapped, so inner links are fine there.
+- **No new runtime dependencies.** Pure Tailwind 4 / daisyUI 5 / CSS. `@lucide/svelte` is already available for icons.
+- **Preserve prerendering.** No changes to `entries()` or load logic beyond the `all` flag.
+- **Both themes first-class.** Verify contrast (AA) for accents and text in light *and* dark — especially gold and blue.
+- **Don't touch** `lib/components/cube/*`, `packages/cube`, the `lib/data/tables/*.json` data, or routing.
+
+## Out of scope / non-goals
+
+New features or pages; cube-rendering changes; data/schema changes; search/keyboard-nav behavior changes; wiring the real `packages/db`.
+
+## Success criteria
+
+- All four route levels (`/`, `/[setId]`, `/[setId]/[subsetId]`, `/[setId]/[subsetId]/[caseId]`) match the approved mockup's look in **both** themes, with the type-color system applied consistently.
+- Mobile drawer (sidebar) still opens/closes and the layout is responsive.
+- `bun run check` (svelte-check), `bun run lint` (prettier + eslint), and `bun run test` all pass.
+- No nested-anchor or focus-visibility regressions.
+- Verified visually via the preview tool: screenshots of each route level, both themes, plus a mobile width.


### PR DESCRIPTION
## Summary

A visual refresh of the SvelteKit client — a cohesive, cube-themed look ("Playful Cube") built around a **type-based color system**, applied consistently across both light and dark themes. Surfaces only; the cube-rendering engine, data tables, and routing are untouched.

Approved via a brainstorming pass — design doc: [`docs/superpowers/specs/2026-06-04-ui-cleanup-playful-cube-design.md`](docs/superpowers/specs/2026-06-04-ui-cleanup-playful-cube-design.md).

## What's new

- **Type color system** — F2L = green, OLL = gold, PLL = blue, "All" = cube gradient. Drives the sidebar section dots + active bars, the type chips, and each case card's accent bar + pill. Implemented with a `data-type` → `--type-accent` CSS-variable pattern (no per-color class sprawl), so themes and contrast are tuned in one place.
- **Tuned daisyUI themes** — custom `light`/`dark` themes: raised `base-100` cards on a `base-200` page, friendlier radii, subtle depth.
- **Case cards** — rebuilt around the cube as hero: accent bar, faint type tint, bold name + colored type pill, algorithms as monospace chips with the ✓ verifier inline, and **Setup demoted** from a bordered box to a quiet footer line.
- **Type chips** — colored top edge, count pill, active ring, hover lift; cubes top-aligned with titles below so they line up regardless of title length.
- **Shell** — gradient cube logo mark, sticky blurred header, comfortable max-width content column.
- **Data** — added an explicit `all` flag to `PreviewItem` so the home gradient chip no longer inherits a misleading hardcoded `viewType: 'PLL'`.

## Out of scope

Cube-rendering internals (`lib/components/cube/*`), the `packages/cube` engine, the `tables/*.json` data, and routing logic.

## Verification

| Check | Result |
| --- | --- |
| `bun run check` (svelte-check) | 0 errors, 0 warnings |
| `bun run lint` (prettier + eslint) | clean |
| `bun run test` | 12/12 passing |
| Manual | all four route levels in **both themes** + mobile drawer |
| Type-pill contrast | WCAG AA-safe — F2L 5.0, OLL 8.2, PLL 5.2 : 1 |

## Notes

The cube's grey `#808080` "don't care" stickers are the cube engine's own rendering (left untouched) — they read a little flat on light backgrounds. Easy follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
