### PR TITLE
fix(deploy): alias bun:sqlite so the Worker bundles (unblocks production deploy)

### DIFF
--- a/apps/client/bun-sqlite-shim.js
+++ b/apps/client/bun-sqlite-shim.js
@@ -1,0 +1,31 @@
+// Shim for `bun:sqlite` in the Cloudflare Worker bundle.
+//
+// All DB access happens at build/prerender time (under Bun), where the real
+// `bun:sqlite` is used. The deployed Worker only serves prerendered static
+// assets and never opens a database — but wrangler/esbuild still has to *bundle*
+// the (dead) `db` import that the prerender remote functions pull in, and
+// workerd has no `bun:sqlite`. This shim satisfies the bundler and is written to
+// be crash-proof (no-ops returning empty results) on the off chance the module
+// is evaluated at Worker startup; its query methods are never actually reached.
+const emptyStatement = {
+	all: () => [],
+	get: () => undefined,
+	values: () => [],
+	run: () => ({ changes: 0, lastInsertRowid: 0 }),
+	finalize: () => {}
+};
+
+export class Database {
+	constructor() {}
+	query() {
+		return emptyStatement;
+	}
+	prepare() {
+		return emptyStatement;
+	}
+	run() {}
+	exec() {}
+	close() {}
+}
+
+export default Database;

--- a/apps/client/wrangler.jsonc
+++ b/apps/client/wrangler.jsonc
@@ -2,6 +2,11 @@
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "cubing",
 	"main": ".svelte-kit/cloudflare/_worker.js",
+	// `db` (Drizzle + bun:sqlite) is pulled into the Worker bundle via the
+	// prerender remote functions, but all DB access is prerendered at build time —
+	// the Worker never runs it. Alias bun:sqlite to a no-op shim so wrangler can
+	// bundle the dead import (workerd has no bun:sqlite).
+	"alias": { "bun:sqlite": "./bun-sqlite-shim.js" },
 	"compatibility_date": "2025-09-23",
 	"compatibility_flags": ["nodejs_als"],
 	"assets": {


### PR DESCRIPTION
## Summary

PR #874 merged the db-backed data layer + cube navigation, but the **production deploy is broken**: `wrangler deploy` (run by `deploy.yml` on push to `main`) fails to bundle the Worker —

```
✘ [ERROR] Could not resolve "bun:sqlite"
  ../../packages/db/dist/index.js  /  drizzle-orm/bun-sqlite/driver.js
```

The prerender remote functions pull `db` (Drizzle + `bun:sqlite`) into the SvelteKit server bundle, which adapter-cloudflare wraps into the Worker. **All DB access is prerendered at build time**, so that code is dead in the Worker — but wrangler/esbuild still has to *bundle* the import, and workerd has no `bun:sqlite`.

Fix (as the wrangler error itself recommends): alias `bun:sqlite` to a crash-proof no-op shim, scoped to the Worker bundle only. The build/prerender step (under Bun) still uses the real `bun:sqlite`.

- `apps/client/bun-sqlite-shim.js` — no-op `Database` (constructs cleanly; query methods return empty if ever reached, which they aren't).
- `apps/client/wrangler.jsonc` — `"alias": { "bun:sqlite": "./bun-sqlite-shim.js" }`.

## Test Plan

- [x] `bun run build` — green (turbo db + client)
- [x] `bunx wrangler deploy --dry-run` — bundles cleanly (745 KiB), no `bun:sqlite` errors
- [x] `wrangler dev` (workerd) — serves `/` and `/3x3/OLL/Oriented-Edges/OLL-21` at HTTP 200 with prerendered content (Worker starts fine with the shim)
- [ ] CI + production deploy green on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)